### PR TITLE
manifest: Update npm dependencies

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -6,53 +6,67 @@
         "type": "shell"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/db/b7",
-        "dest-filename": "78959a28995ca8e7555e831236d3164fb921eeb2a6d06a0ff3b6b042ef07a05a84359cb4443d548a496f1bca14e5cd32b2344e227da4c0ea50a9ec98e917",
-        "sha512": "dbb778959a28995ca8e7555e831236d3164fb921eeb2a6d06a0ff3b6b042ef07a05a84359cb4443d548a496f1bca14e5cd32b2344e227da4c0ea50a9ec98e917",
+        "dest": "npm-cache/_cacache/content-v2/sha512/6b/d8",
+        "dest-filename": "31a66757b591089e40921d42432c76550606f5412d2386cb3870f3fddc45bbb3eb82e5b8a4113dadc04177295fbbac36e525c98dbd347b5497a3a9dd82da",
+        "sha512": "6bd831a66757b591089e40921d42432c76550606f5412d2386cb3870f3fddc45bbb3eb82e5b8a4113dadc04177295fbbac36e525c98dbd347b5497a3a9dd82da",
         "type": "file",
-        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz"
+        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/ed/d5",
-        "dest-filename": "787aef60071a0cd1d0278ff0421435bd2c5534cef4eb92ad2e80cee99c712082e38478ecf5b28d9982111dcef898cd01040f4af8100829b010a12b2d5345",
-        "sha512": "edd5787aef60071a0cd1d0278ff0421435bd2c5534cef4eb92ad2e80cee99c712082e38478ecf5b28d9982111dcef898cd01040f4af8100829b010a12b2d5345",
+        "dest": "npm-cache/_cacache/content-v2/sha512/3d/7e",
+        "dest-filename": "32e71414bf2d1f9c4547ad839aad13d755669f4a34d6f53d0769bf205486b0a65d928f4391cabca000dabe2a370d952493c346022d2340f0ec99d48e3212",
+        "sha512": "3d7e32e71414bf2d1f9c4547ad839aad13d755669f4a34d6f53d0769bf205486b0a65d928f4391cabca000dabe2a370d952493c346022d2340f0ec99d48e3212",
         "type": "file",
-        "url": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz"
+        "url": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/90/be",
-        "dest-filename": "42ba85c0fdd8319416d5adf96c7e5cd0dcf01ab3b458641e7634e9bfebcdfd89560980a309ddc4090feb768b9faa15af21dcc0e910e2624bae04f092e749",
-        "sha512": "90be42ba85c0fdd8319416d5adf96c7e5cd0dcf01ab3b458641e7634e9bfebcdfd89560980a309ddc4090feb768b9faa15af21dcc0e910e2624bae04f092e749",
+        "dest": "npm-cache/_cacache/content-v2/sha512/ae/bf",
+        "dest-filename": "8e432023c737bb1a05ab49a270c9d1d2b48847ab696f63704e0b6323eca9f323b5cad14c354ce39d23d943a1a8c46d258b898828a387f5479d5ead07e13d",
+        "sha512": "aebf8e432023c737bb1a05ab49a270c9d1d2b48847ab696f63704e0b6323eca9f323b5cad14c354ce39d23d943a1a8c46d258b898828a387f5479d5ead07e13d",
         "type": "file",
-        "url": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz"
+        "url": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/b4/c5",
-        "dest-filename": "2ac0159f2c56c96e2cd198471648bc3a1e71737dd26cdac38910ec30b553cca07ff4032f84ef4de8673efc5525d98a20dc66b4395ca8cf214422c619a057",
-        "sha512": "b4c52ac0159f2c56c96e2cd198471648bc3a1e71737dd26cdac38910ec30b553cca07ff4032f84ef4de8673efc5525d98a20dc66b4395ca8cf214422c619a057",
+        "dest": "npm-cache/_cacache/content-v2/sha512/69/d7",
+        "dest-filename": "7b760039a6944fc42149a0019f3038bb3c8057ab546d1a8ec185b2dac70ad73ce9b0f20ab8f18f68cd3d358542b2f5bc8c8e5476d04261bb9ce5904ac492",
+        "sha512": "69d77b760039a6944fc42149a0019f3038bb3c8057ab546d1a8ec185b2dac70ad73ce9b0f20ab8f18f68cd3d358542b2f5bc8c8e5476d04261bb9ce5904ac492",
         "type": "file",
-        "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz"
+        "url": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/4d/7b",
-        "dest-filename": "54504607b9a4c46cb65620a52be69981ba10cbcbef0a62d3d875c57ca82fa93992fe34aa98c2f59246b5571e7f99991440bbcbc94c0ce71fb39a83a45547",
-        "sha512": "4d7b54504607b9a4c46cb65620a52be69981ba10cbcbef0a62d3d875c57ca82fa93992fe34aa98c2f59246b5571e7f99991440bbcbc94c0ce71fb39a83a45547",
+        "dest": "npm-cache/_cacache/content-v2/sha512/1e/25",
+        "dest-filename": "17ffe2b662992927e4b305f7e433f010d98134dd2d14d648d32d5a6825d85930e5b2f2abd754df4974baafd90b1a43a30f61022e366c03f333a2614a1f2d",
+        "sha512": "1e2517ffe2b662992927e4b305f7e433f010d98134dd2d14d648d32d5a6825d85930e5b2f2abd754df4974baafd90b1a43a30f61022e366c03f333a2614a1f2d",
         "type": "file",
-        "url": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz"
+        "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/0a/0d",
-        "dest-filename": "f298c01d375d303a4fd561f2d5eca090cafec40e2ac9eb8e74d2c53b9fd5259a2a04b43b94e4677e863ef7857494fdec7bb47252b2c9b27ed0dd90c2cef1",
-        "sha512": "0a0df298c01d375d303a4fd561f2d5eca090cafec40e2ac9eb8e74d2c53b9fd5259a2a04b43b94e4677e863ef7857494fdec7bb47252b2c9b27ed0dd90c2cef1",
+        "dest": "npm-cache/_cacache/content-v2/sha512/0f/a8",
+        "dest-filename": "058850344512f251bbe28cdef80d60235d217158a6963fb9a5771915872840577f92580f471093c743673db2821e4c526a7127450c616076ab358945361f",
+        "sha512": "0fa8058850344512f251bbe28cdef80d60235d217158a6963fb9a5771915872840577f92580f471093c743673db2821e4c526a7127450c616076ab358945361f",
         "type": "file",
-        "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz"
+        "url": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/d5/aa",
-        "dest-filename": "5e3df5ccd54392ab0d28f48885028bd5cfd3394b50e0fb84eb0f07cc7b043aa7fae632e79beed5998d0d6bc782e8cb502b060828a86a5faaa748e2ba2776",
-        "sha512": "d5aa5e3df5ccd54392ab0d28f48885028bd5cfd3394b50e0fb84eb0f07cc7b043aa7fae632e79beed5998d0d6bc782e8cb502b060828a86a5faaa748e2ba2776",
+        "dest": "npm-cache/_cacache/content-v2/sha512/25/61",
+        "dest-filename": "7ba1ca8dae9f2ef68aa9815fb01f97ed6edf9c7efbfe3d38cebca2d3dc0758972fcb98e44045f1154f58b28f037ee0ca84e549952a801d201a9ea021e02c",
+        "sha512": "25617ba1ca8dae9f2ef68aa9815fb01f97ed6edf9c7efbfe3d38cebca2d3dc0758972fcb98e44045f1154f58b28f037ee0ca84e549952a801d201a9ea021e02c",
         "type": "file",
-        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz"
+        "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/39/d8",
+        "dest-filename": "d72719c237502fc8b4b378a2205d35f157ef7d66e5e5dc7a68f57a4902ff4c05c1ebac9390e6457bca95ceb9089ef809961b6e612db88a77061389fcdc7d",
+        "sha512": "39d8d72719c237502fc8b4b378a2205d35f157ef7d66e5e5dc7a68f57a4902ff4c05c1ebac9390e6457bca95ceb9089ef809961b6e612db88a77061389fcdc7d",
+        "type": "file",
+        "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/6d/8e",
+        "dest-filename": "9f8f9e8e510d215352a314d0d0b8915ecea29dac0c857487af0038aaad61f04a56e604d307a796a4d9fe343e6f094c5c8cda6ab1906ea78241ced757ff96",
+        "sha512": "6d8e9f8f9e8e510d215352a314d0d0b8915ecea29dac0c857487af0038aaad61f04a56e604d307a796a4d9fe343e6f094c5c8cda6ab1906ea78241ced757ff96",
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/55/3d",
@@ -223,11 +237,11 @@
         "url": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/b0/ad",
-        "dest-filename": "ee8eb8b4e16ca3c105d5a0ae0f537cbcba56b5b2dab5d06259a6a1c8520a0665db06cc01aeeb9067537774f1a4d54af3bb9863d951cd304c40cbfaa184d1",
-        "sha512": "b0adee8eb8b4e16ca3c105d5a0ae0f537cbcba56b5b2dab5d06259a6a1c8520a0665db06cc01aeeb9067537774f1a4d54af3bb9863d951cd304c40cbfaa184d1",
+        "dest": "npm-cache/_cacache/content-v2/sha512/db/fc",
+        "dest-filename": "4f6f7391b10e369c76224ae9d79038cf2c16848ffc53c143b807b5c26504d193b101b5338f6b2821d74600021d8e23542ba7a3567e9021cecc23d3276df6",
+        "sha512": "dbfc4f6f7391b10e369c76224ae9d79038cf2c16848ffc53c143b807b5c26504d193b101b5338f6b2821d74600021d8e23542ba7a3567e9021cecc23d3276df6",
         "type": "file",
-        "url": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz"
+        "url": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/e4/73",
@@ -286,11 +300,11 @@
         "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/3e/91",
-        "dest-filename": "01abb6faa98feaace9a9610fe34cc0d87ee40c10b478838588d4cfcd6920c30ff6dd70c6fe763e07824b3ba78d645b671a5ec3ec1190040320208d5542d2",
-        "sha512": "3e9101abb6faa98feaace9a9610fe34cc0d87ee40c10b478838588d4cfcd6920c30ff6dd70c6fe763e07824b3ba78d645b671a5ec3ec1190040320208d5542d2",
+        "dest": "npm-cache/_cacache/content-v2/sha512/2b/e2",
+        "dest-filename": "1acb2a362edc98843498c33e43e50756c3484269c373caad58f36d579dadb14898fb7228e82cb6262f14d081c819f660bad67af2332f52ec645b62923922",
+        "sha512": "2be21acb2a362edc98843498c33e43e50756c3484269c373caad58f36d579dadb14898fb7228e82cb6262f14d081c819f660bad67af2332f52ec645b62923922",
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz"
+        "url": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/a1/8a",
@@ -314,11 +328,11 @@
         "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/da/25",
-        "dest-filename": "0fbae3cffb25b53d968c48333d7b255ff03e4fd078bc87cdd8b59e5b3dcff31d88c8239921a22c4851330eefde0d398f05fd3845d41a3c9dc6482daad44c",
-        "sha512": "da250fbae3cffb25b53d968c48333d7b255ff03e4fd078bc87cdd8b59e5b3dcff31d88c8239921a22c4851330eefde0d398f05fd3845d41a3c9dc6482daad44c",
+        "dest": "npm-cache/_cacache/content-v2/sha512/ca/c0",
+        "dest-filename": "b145063759a5c9cfdb5d6d63b0b96af963f5eb3d3197f4a8b3df2a145f05b4559e30df41d39102da1b1ffeb6d16317c8be0026c0ae707871eebc6bd9b987",
+        "sha512": "cac0b145063759a5c9cfdb5d6d63b0b96af963f5eb3d3197f4a8b3df2a145f05b4559e30df41d39102da1b1ffeb6d16317c8be0026c0ae707871eebc6bd9b987",
         "type": "file",
-        "url": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz"
+        "url": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/78/6b",
@@ -328,11 +342,11 @@
         "url": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/4a/68",
-        "dest-filename": "b2679cc8587f5533e49151178b4b943c6bb1b1b51771101559a66f7cac933b49bf80f435429dd5df91e1547776f275eae0f846c391f9debdf0b0ca759a34",
-        "sha512": "4a68b2679cc8587f5533e49151178b4b943c6bb1b1b51771101559a66f7cac933b49bf80f435429dd5df91e1547776f275eae0f846c391f9debdf0b0ca759a34",
+        "dest": "npm-cache/_cacache/content-v2/sha512/33/16",
+        "dest-filename": "16f712a644e585ebbd8aaa33bbe6cb33b00f0cc61c34e9815e4b9547941f7c2831db392bab9b702bb233bad0469fdd09863023f5ca7fb425090d2e8ffded",
+        "sha512": "331616f712a644e585ebbd8aaa33bbe6cb33b00f0cc61c34e9815e4b9547941f7c2831db392bab9b702bb233bad0469fdd09863023f5ca7fb425090d2e8ffded",
         "type": "file",
-        "url": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz"
+        "url": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/eb/84",
@@ -370,18 +384,18 @@
         "url": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha1/7b/05",
-        "dest-filename": "218ddf9667bf7f370bf7fdb2cb15fdd0aa49",
-        "sha1": "7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49",
+        "dest": "npm-cache/_cacache/content-v2/sha512/f1/41",
+        "dest-filename": "1ae7c4032dab8335fa5bad7e7943d8eb1874e1c3664c74e932e46975083b557890cf56b1b8271c7537c8f0da091669f7f9514b97d4a25dfbdcc67b607e64",
+        "sha512": "f1411ae7c4032dab8335fa5bad7e7943d8eb1874e1c3664c74e932e46975083b557890cf56b1b8271c7537c8f0da091669f7f9514b97d4a25dfbdcc67b607e64",
         "type": "file",
-        "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz"
+        "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha1/d5/14",
-        "dest-filename": "2c0caee6b1189f87d3a76111064f86c8bbf2",
-        "sha1": "d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "dest": "npm-cache/_cacache/content-v2/sha512/96/17",
+        "dest-filename": "7fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+        "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
         "type": "file",
-        "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+        "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/3d/8a",
@@ -391,11 +405,11 @@
         "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/ad/ab",
-        "dest-filename": "e1f15457a87b8cbd9b7f77c19b9417aa0cc91d24c05dbffd8a9ed147fab6b931790eee7c4d2a9cd0de7e900ffd9d6b5907d1a5a634849dbe133b825da056",
-        "sha512": "adabe1f15457a87b8cbd9b7f77c19b9417aa0cc91d24c05dbffd8a9ed147fab6b931790eee7c4d2a9cd0de7e900ffd9d6b5907d1a5a634849dbe133b825da056",
+        "dest": "npm-cache/_cacache/content-v2/sha512/c9/a7",
+        "dest-filename": "6e40544a2d760e1a0127e8065abbdd23de08123b28aa5d4d05f4965f79762135af899385feb38e40db38398e7b3cec60056b7e01066da45f0e17a4d71b76",
+        "sha512": "c9a76e40544a2d760e1a0127e8065abbdd23de08123b28aa5d4d05f4965f79762135af899385feb38e40db38398e7b3cec60056b7e01066da45f0e17a4d71b76",
         "type": "file",
-        "url": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz"
+        "url": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/6c/28",
@@ -433,11 +447,11 @@
         "url": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/27/d7",
-        "dest-filename": "65b24a945cad4e7933980449f9b3c68cba458cc167ecfab3d39ff8e7e74531e0c357561b9b2f5c2efe3dadf87e0d548f9c5c47026987a596a68f5465cda9",
-        "sha512": "27d765b24a945cad4e7933980449f9b3c68cba458cc167ecfab3d39ff8e7e74531e0c357561b9b2f5c2efe3dadf87e0d548f9c5c47026987a596a68f5465cda9",
+        "dest": "npm-cache/_cacache/content-v2/sha512/2f/06",
+        "dest-filename": "b1c3267bd8b93bbd920db4d36bcb05f466e2f24adadd0ed69b79f64a018e59189855b607739e5b917acc4d98f8ad1344803be3b6eac5931de292236c0c04",
+        "sha512": "2f06b1c3267bd8b93bbd920db4d36bcb05f466e2f24adadd0ed69b79f64a018e59189855b607739e5b917acc4d98f8ad1344803be3b6eac5931de292236c0c04",
         "type": "file",
-        "url": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz"
+        "url": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/aa/3b",
@@ -447,11 +461,11 @@
         "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/58/e0",
-        "dest-filename": "69fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354",
-        "sha512": "58e069fc410652222c252a7bc1cbffcba30efa557d5289dc5aac6e15f9bc781c3358d8327c177a1b3f8878a43d8c29b28681fdf60d793374fe41a5471638b354",
+        "dest": "npm-cache/_cacache/content-v2/sha512/05/62",
+        "dest-filename": "02bb3cc3bc3a07e78347282b1e0da9c0844dc2783a2b8032f9313e8b3175e3d960a777d502daccdd9380162df8dd80d0425cb51a9d761ca4104a392586c2",
+        "sha512": "056202bb3cc3bc3a07e78347282b1e0da9c0844dc2783a2b8032f9313e8b3175e3d960a777d502daccdd9380162df8dd80d0425cb51a9d761ca4104a392586c2",
         "type": "file",
-        "url": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
+        "url": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/b5/d4",
@@ -482,11 +496,11 @@
         "url": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/3e/9b",
-        "dest-filename": "a4b07286b7cad77d612bf66f441c8a60cb26a5b41cbcf9e17a189334402031320c427ee70c1779a379c2b642c26bd1a9895bb813aa1e7fc21b74cf652111",
-        "sha512": "3e9ba4b07286b7cad77d612bf66f441c8a60cb26a5b41cbcf9e17a189334402031320c427ee70c1779a379c2b642c26bd1a9895bb813aa1e7fc21b74cf652111",
+        "dest": "npm-cache/_cacache/content-v2/sha512/e9/ed",
+        "dest-filename": "6ad5c9d63f64570fdfe47929311d2720e74f02757a975a05816844cd872b81173fa451994a6e887e2122be6d4fbe0e66c78a6541acecffcf33ded2c677b1",
+        "sha512": "e9ed6ad5c9d63f64570fdfe47929311d2720e74f02757a975a05816844cd872b81173fa451994a6e887e2122be6d4fbe0e66c78a6541acecffcf33ded2c677b1",
         "type": "file",
-        "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz"
+        "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/92/18",
@@ -510,11 +524,60 @@
         "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/ad/27",
-        "dest-filename": "42ef37a51dd4501645a786c32edbed923b8d66a6fda8176cf2e2d3219a22d691c29b380b3cedf580261557b6d295c21759bf29af9ee33de44c845e0dbfb5",
-        "sha512": "ad2742ef37a51dd4501645a786c32edbed923b8d66a6fda8176cf2e2d3219a22d691c29b380b3cedf580261557b6d295c21759bf29af9ee33de44c845e0dbfb5",
+        "dest": "npm-cache/_cacache/content-v2/sha512/e5/f2",
+        "dest-filename": "4c5849a291262ed27bff7e531ce3be4c8466c1ed348f77fd88a45578238acc9256e8087dab423618e642a26061ea505f60bda6a66eea5c245146f5dbd17a",
+        "sha512": "e5f24c5849a291262ed27bff7e531ce3be4c8466c1ed348f77fd88a45578238acc9256e8087dab423618e642a26061ea505f60bda6a66eea5c245146f5dbd17a",
         "type": "file",
-        "url": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz"
+        "url": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/f5/51",
+        "dest-filename": "a3accb06d6f78fc5c4b0790b0ddb4298fdce3337487d7cb8ea01bc1b3df6a1337b7e34bf8cf470bcc5e5c6d88f295f93686a64c636ea26114148edf7148c",
+        "sha512": "f551a3accb06d6f78fc5c4b0790b0ddb4298fdce3337487d7cb8ea01bc1b3df6a1337b7e34bf8cf470bcc5e5c6d88f295f93686a64c636ea26114148edf7148c",
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/e0/3d",
+        "dest-filename": "c1e967f8d4a39844576cce60ea3021aae5557fb8c001dbbdc920b98efb78c0961f17e2a0ed76d8024777f1b5b2c43334b1db641d8670dc26fbb6bb57d5c2",
+        "sha512": "e03dc1e967f8d4a39844576cce60ea3021aae5557fb8c001dbbdc920b98efb78c0961f17e2a0ed76d8024777f1b5b2c43334b1db641d8670dc26fbb6bb57d5c2",
+        "type": "file",
+        "url": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/45/11",
+        "dest-filename": "023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/74/ec",
+        "dest-filename": "bedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/13/29",
+        "dest-filename": "094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/02/eb",
+        "dest-filename": "ca4eb4df40d60d21cb5b4752bf6064d1d7be7a1b270fb20edbf5b755f43baababe20bfa68aa875da87aed9f08992ed6133e5055c3ad95f5b6ad912e82deb",
+        "sha512": "02ebca4eb4df40d60d21cb5b4752bf6064d1d7be7a1b270fb20edbf5b755f43baababe20bfa68aa875da87aed9f08992ed6133e5055c3ad95f5b6ad912e82deb",
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/a1/14",
+        "dest-filename": "88a51f29c53d56af616ab9336719eb7bf5bdc15a58ea3aea16fe1e28061c49fc751b5f99d7e894abb9392f5c30853300cfbec6934dbbcc2ca6564b2d11e6",
+        "sha512": "a11488a51f29c53d56af616ab9336719eb7bf5bdc15a58ea3aea16fe1e28061c49fc751b5f99d7e894abb9392f5c30853300cfbec6934dbbcc2ca6564b2d11e6",
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/a8/8c",
@@ -573,11 +636,11 @@
         "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/7b/b2",
-        "dest-filename": "99802497309c739c4ff85942f3c9b08c35734077f6dfe534abbd512aefc43f2bc670169981a90783b4d887737978f6757813ff9878753f2598d2508acb00",
-        "sha512": "7bb299802497309c739c4ff85942f3c9b08c35734077f6dfe534abbd512aefc43f2bc670169981a90783b4d887737978f6757813ff9878753f2598d2508acb00",
+        "dest": "npm-cache/_cacache/content-v2/sha512/a2/86",
+        "dest-filename": "83fe1ac13e1bb7e715d6e209fea3748ebb386def781d06e7df809ceb6412593c68068a24ef244813cb116f04eda7cf4f97d46e9eb45f12cd43834e52d8e9",
+        "sha512": "a28683fe1ac13e1bb7e715d6e209fea3748ebb386def781d06e7df809ceb6412593c68068a24ef244813cb116f04eda7cf4f97d46e9eb45f12cd43834e52d8e9",
         "type": "file",
-        "url": "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz"
+        "url": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/1e/15",
@@ -685,11 +748,11 @@
         "url": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha1/36/4c",
-        "dest-filename": "5e409d3f4d6301d6c0b4c05bba50180aeb64",
-        "sha1": "364c5e409d3f4d6301d6c0b4c05bba50180aeb64",
+        "dest": "npm-cache/_cacache/content-v2/sha512/f8/85",
+        "dest-filename": "bda4009d9375d69a64d71bc9b7ba919426cb795d11b3c4c4635f302e2755e720536f7e18e322e6240efcac9cf43bab3a95ccbb7bf010abba7b6a4615906c",
+        "sha512": "f885bda4009d9375d69a64d71bc9b7ba919426cb795d11b3c4c4635f302e2755e720536f7e18e322e6240efcac9cf43bab3a95ccbb7bf010abba7b6a4615906c",
         "type": "file",
-        "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
+        "url": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/bb/e6",
@@ -783,18 +846,18 @@
         "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha1/03/71",
-        "dest-filename": "ab4ae0bdd720d4166d7dfda64ff7a445a6c0",
-        "sha1": "0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0",
+        "dest": "npm-cache/_cacache/content-v2/sha512/c4/94",
+        "dest-filename": "db87f77b2e6ed2061735b4dbd3a5e087684ce8cb13eba8d96f49d31f053630698fbe5091725d43b102db115178e5a8e7e3f25b8d691f6f8c287829e57ea6",
+        "sha512": "c494db87f77b2e6ed2061735b4dbd3a5e087684ce8cb13eba8d96f49d31f053630698fbe5091725d43b102db115178e5a8e7e3f25b8d691f6f8c287829e57ea6",
         "type": "file",
-        "url": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz"
+        "url": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/c2/e6",
-        "dest-filename": "2c0186057564c09c068fa0a18d85fa56c0a65b256f8780027e9889a9f84a65ec11bca0d581093c9133c81b6bd938964f01816768626db5328fd162185b80",
-        "sha512": "c2e62c0186057564c09c068fa0a18d85fa56c0a65b256f8780027e9889a9f84a65ec11bca0d581093c9133c81b6bd938964f01816768626db5328fd162185b80",
+        "dest": "npm-cache/_cacache/content-v2/sha512/9d/a3",
+        "dest-filename": "105dc804a3772c0041afc3f3727510347ee4b69c36498b0d5851614a53b68f3c03c6644b03e088a68adf7aab00a2787eb2eb5e0c08b630764ad6c7bcffed",
+        "sha512": "9da3105dc804a3772c0041afc3f3727510347ee4b69c36498b0d5851614a53b68f3c03c6644b03e088a68adf7aab00a2787eb2eb5e0c08b630764ad6c7bcffed",
         "type": "file",
-        "url": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz"
+        "url": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/61/9a",
@@ -860,11 +923,18 @@
         "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/36/b5",
-        "dest-filename": "fed5d55587ee98f5d9d0d7da51d293f8162108954bdd4c69fca70e8229336ae6c8226f69c886650d4f94c09a15a6bcaaf759cc4170fdc4f2759ecee8a9b9",
-        "sha512": "36b5fed5d55587ee98f5d9d0d7da51d293f8162108954bdd4c69fca70e8229336ae6c8226f69c886650d4f94c09a15a6bcaaf759cc4170fdc4f2759ecee8a9b9",
+        "dest": "npm-cache/_cacache/content-v2/sha512/cd/4c",
+        "dest-filename": "f9243fad82ab6e0e3321c08839b85555dddb6a67dc902656557eae08d35fcae4f6a3e541e3ed5cab40e26fcdac125652a939b0296df0f411deb225cfb57a",
+        "sha512": "cd4cf9243fad82ab6e0e3321c08839b85555dddb6a67dc902656557eae08d35fcae4f6a3e541e3ed5cab40e26fcdac125652a939b0296df0f411deb225cfb57a",
         "type": "file",
-        "url": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz"
+        "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/02/eb",
+        "dest-filename": "ca4eb4df40d60d21cb5b4752bf6064d1d7be7a1b270fb20edbf5b755f43baababe20bfa68aa875da87aed9f08992ed6133e5055c3ad95f5b6ad912e82deb",
+        "sha512": "02ebca4eb4df40d60d21cb5b4752bf6064d1d7be7a1b270fb20edbf5b755f43baababe20bfa68aa875da87aed9f08992ed6133e5055c3ad95f5b6ad912e82deb",
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/62/e2",
@@ -879,6 +949,13 @@
         "sha512": "0ee46cd6029b06ab0c288665adf7f096e83c30791c9e98ece553e62f53c087e980df45340d3a2d7c3674776514b17a4f98f98c309e96efbdcc680dc9fa56e258",
         "type": "file",
         "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz"
+    },
+    {
+        "dest": "npm-cache/_cacache/content-v2/sha512/d5/aa",
+        "dest-filename": "5e3df5ccd54392ab0d28f48885028bd5cfd3394b50e0fb84eb0f07cc7b043aa7fae632e79beed5998d0d6bc782e8cb502b060828a86a5faaa748e2ba2776",
+        "sha512": "d5aa5e3df5ccd54392ab0d28f48885028bd5cfd3394b50e0fb84eb0f07cc7b043aa7fae632e79beed5998d0d6bc782e8cb502b060828a86a5faaa748e2ba2776",
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/55/3c",
@@ -944,11 +1021,11 @@
         "url": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/a8/e7",
-        "dest-filename": "9b179ddfae77bcd5c7f44bd078d41c9e9c9dff22e1fcc892a78005f7e429a2672480d24861928bec84a2be8c609a3275689a56bb81594871cdc4bca3db4d",
-        "sha512": "a8e79b179ddfae77bcd5c7f44bd078d41c9e9c9dff22e1fcc892a78005f7e429a2672480d24861928bec84a2be8c609a3275689a56bb81594871cdc4bca3db4d",
+        "dest": "npm-cache/_cacache/content-v2/sha512/69/95",
+        "dest-filename": "bcf1263c9106d4ee0a55d7d94ddb82ed5e1ff20f865983aaa27802430e0f9806c25c4a62c62bd4299d48c02951bfc5e7e6bc919dd565267e94ff83a00918",
+        "sha512": "6995bcf1263c9106d4ee0a55d7d94ddb82ed5e1ff20f865983aaa27802430e0f9806c25c4a62c62bd4299d48c02951bfc5e7e6bc919dd565267e94ff83a00918",
         "type": "file",
-        "url": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz"
+        "url": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/58/84",
@@ -958,11 +1035,11 @@
         "url": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha512/0d/69",
-        "dest-filename": "12e3d1102955fffd36eea5bf5315ad7d73bf8c2b55e6ce4ad9511f13024b6613f0e2cd7a1aa0957a4d9fed4883d78a9a8d89123a0b201eef1ebd25be914b",
-        "sha512": "0d6912e3d1102955fffd36eea5bf5315ad7d73bf8c2b55e6ce4ad9511f13024b6613f0e2cd7a1aa0957a4d9fed4883d78a9a8d89123a0b201eef1ebd25be914b",
+        "dest": "npm-cache/_cacache/content-v2/sha512/e1/d6",
+        "dest-filename": "f3233aaf8ed822339af0d64e6b107b4100d2a676e7611b20446a3374d5f13285a00886ca0a372eb2efe20df7721fa45b7063d8aa8bb903fb1c0a850b0d24",
+        "sha512": "e1d6f3233aaf8ed822339af0d64e6b107b4100d2a676e7611b20446a3374d5f13285a00886ca0a372eb2efe20df7721fa45b7063d8aa8bb903fb1c0a850b0d24",
         "type": "file",
-        "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz"
+        "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha512/29/8f",
@@ -986,11 +1063,11 @@
         "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
     },
     {
-        "dest": "npm-cache/_cacache/content-v2/sha1/27/58",
-        "dest-filename": "4810891456a4171c8d0226441ade90cbcaeb",
-        "sha1": "27584810891456a4171c8d0226441ade90cbcaeb",
+        "dest": "npm-cache/_cacache/content-v2/sha512/1f/3f",
+        "dest-filename": "e6acdc22b4d461fc7500b4cfd54ffe551feca00fa0d5ee660a640b473ab6ecf14ee5bcf4bac5fec424a305d2e5b52890a5d07ef4d60dd91aeb3e9ae139bd",
+        "sha512": "1f3fe6acdc22b4d461fc7500b4cfd54ffe551feca00fa0d5ee660a640b473ab6ecf14ee5bcf4bac5fec424a305d2e5b52890a5d07ef4d60dd91aeb3e9ae139bd",
         "type": "file",
-        "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+        "url": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
     },
     {
         "dest": "npm-cache/_cacache/content-v2/sha1/b5/24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,56 +5,68 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-      "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "requires": {
-        "type-fest": "^0.5.2"
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+        }
       }
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -224,9 +236,9 @@
       }
     },
     "dom-serializer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
-      "integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "requires": {
         "domelementtype": "^2.0.1",
         "entities": "^2.0.0"
@@ -282,9 +294,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
-      "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -301,7 +313,7 @@
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -314,7 +326,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -348,12 +360,12 @@
       "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
@@ -363,9 +375,9 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "requires": {
         "estraverse": "^4.0.0"
       }
@@ -404,14 +416,14 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -419,9 +431,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "figures": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -460,9 +472,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "glob": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-      "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -481,9 +493,12 @@
       }
     },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "has-flag": {
       "version": "3.0.0",
@@ -516,9 +531,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "import-fresh": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -544,23 +559,77 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
+        "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "is-extglob": {
@@ -611,9 +680,9 @@
       }
     },
     "jshint": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.2.tgz",
-      "integrity": "sha512-e7KZgCSXMJxznE/4WULzybCMNXNAd/bf5TSrvVEq78Q/K8ZwFpmBqQeDtNiHc3l49nV4E/+YeHU/JZjSUIrLAA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
+      "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
@@ -719,16 +788,16 @@
       }
     },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "os-tmpdir": {
@@ -813,17 +882,17 @@
       }
     },
     "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "requires": {
         "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -884,13 +953,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-      "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^5.2.0"
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "string_decoder": {
@@ -904,6 +983,13 @@
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "requires": {
         "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        }
       }
     },
     "strip-json-comments": {
@@ -971,9 +1057,9 @@
       }
     },
     "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -984,9 +1070,9 @@
       }
     },
     "type-fest": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-      "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -1009,10 +1095,10 @@
         "isexe": "^2.0.0"
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "wrappy": {
       "version": "1.0.2",


### PR DESCRIPTION
GitHub's bot tried to update acorn from 7.1.0 to 7.1.1, but it needs
flatpak-npm-generator run on it, so do it manually.